### PR TITLE
Add support for global sections

### DIFF
--- a/pages.ts
+++ b/pages.ts
@@ -1,5 +1,5 @@
 import { context } from "$live/live.ts";
-import { PageWithParams } from "$live/types.ts";
+import { PageSection, PageWithParams } from "$live/types.ts";
 import getSupabaseClient from "./supabase.ts";
 import { HandlerContext } from "$fresh/server.ts";
 import { EditorData, LiveState, Page } from "$live/types.ts";
@@ -18,6 +18,8 @@ export interface PageOptions {
   selectedPageIds: number[];
 }
 
+export const sectionPathStart = "/_live/workbench/sections/";
+
 export const isPageOptions = (x: any): x is PageOptions =>
   Array.isArray(x.selectedPageIds);
 
@@ -28,8 +30,14 @@ export async function loadLivePage(
 ): Promise<PageWithParams | null> {
   const url = new URL(req.url);
   const pageIdParam = url.searchParams.get("pageId");
+<<<<<<< HEAD
   const blockName = url.searchParams.get("key");
+=======
+  const sectionName = url.pathname.startsWith(sectionPathStart) &&
+    url.pathname.replace(sectionPathStart, "");
+>>>>>>> 7b19de7 (Initial implementation of global section reference using page with global type)
   const pageId = pageIdParam && parseInt(pageIdParam, 10);
+  let globals: Page[] = [];
 
   const pageWithParams = await (async (): Promise<PageWithParams | null> => {
     const { data: pages, error } = await getSupabaseClient()
@@ -38,9 +46,9 @@ export async function loadLivePage(
       .eq("site", context.siteId)
       .in("state", ["published", "draft", "global"]);
 
-    const globalSettings = pages?.filter((page) => page.state === "global") ??
+    globals = pages?.filter((page) => page.state === "global") ??
       [];
-    ctx.state.global = loadGlobal({ globalSettings });
+    ctx.state.global = loadGlobal({ globalSettings: globals });
 
     if (blockName) {
       return fetchPageFromSection(blockName, context.siteId);
@@ -72,6 +80,42 @@ export async function loadLivePage(
 
   if (!pageWithParams) {
     return null;
+  }
+
+  // Now, let's resolve any global sections which may be referenced by this page
+  for (const section of pageWithParams.page.data.sections) {
+    // This section is a reference to a global section, let's find it
+    if (section.key.startsWith(sectionPathStart)) {
+      const [sectionPath] = section.key.split("@");
+      // Look for an override from a feature flag in selectedPageIds
+      let overrideGlobalSection = null;
+      for (const selectedPageId of selectedPageIds) {
+        const selectedGlobalSectionPage = globals.find((globalPage) =>
+          globalPage.path.startsWith(sectionPath) &&
+          globalPage.id === selectedPageId
+        );
+        if (selectedGlobalSectionPage) {
+          overrideGlobalSection = selectedGlobalSectionPage.data
+            .sections[0] as PageSection;
+          break;
+        }
+      }
+      // Look for a global section that matches provided section path exactly
+      let byPathGlobalSection = null;
+      for (const globalPage of globals) {
+        if (globalPage.path === section.key) {
+          byPathGlobalSection = globalPage.data.sections[0] as PageSection;
+          break;
+        }
+      }
+      // Override this section key and props with found match
+      const globalSection = overrideGlobalSection || byPathGlobalSection;
+      if (globalSection) {
+        section.key = globalSection.key;
+        section.label = globalSection.label;
+        section.props = globalSection.props;
+      }
+    }
   }
 
   return {
@@ -173,12 +217,15 @@ export const fetchPageFromId = async (
  * This way we can use the page editor to edit components too
  */
 export const fetchPageFromSection = async (
-  sectionFileName: string, // Ex: ./sections/Banner.tsx
+  sectionFileName: string, // Ex: ./sections/Banner.tsx#TopSellers
   siteId: number,
 ): Promise<PageWithParams> => {
   const supabase = getSupabaseClient();
+  const [sectionPath, sectionName] = sectionFileName.split("@");
+  const sectionKey = `./sections/${sectionPath}`;
   const { section: instance, functions } = createSectionFromSectionKey(
-    sectionFileName,
+    sectionKey,
+    sectionName,
   );
 
   const page = createPageForSection(sectionFileName, {
@@ -186,9 +233,8 @@ export const fetchPageFromSection = async (
     functions,
   });
 
-  // Handle ./sections/SectionName.tsx and $imported/section/Section.tsx
-  if (!doesSectionExist(sectionFileName)) {
-    throw new Error(`Section at ${sectionFileName} Not Found`);
+  if (!doesSectionExist(sectionKey)) {
+    throw new Error(`Section at ${sectionKey} Not Found`);
   }
 
   const { data } = await supabase

--- a/pages.ts
+++ b/pages.ts
@@ -89,6 +89,7 @@ export async function loadLivePage(
       const [sectionPath] = section.key.split("@");
       // Look for an override from a feature flag in selectedPageIds
       let overrideGlobalSection = null;
+      let overrideGlobalLoaders = null;
       for (const selectedPageId of selectedPageIds) {
         const selectedGlobalSectionPage = globals.find((globalPage) =>
           globalPage.path.startsWith(sectionPath) &&
@@ -97,23 +98,31 @@ export async function loadLivePage(
         if (selectedGlobalSectionPage) {
           overrideGlobalSection = selectedGlobalSectionPage.data
             .sections[0] as PageSection;
+          overrideGlobalLoaders = selectedGlobalSectionPage.data.functions;
           break;
         }
       }
       // Look for a global section that matches provided section path exactly
       let byPathGlobalSection = null;
+      let byPathGlobalLoaders = null;
       for (const globalPage of globals) {
         if (globalPage.path === section.key) {
           byPathGlobalSection = globalPage.data.sections[0] as PageSection;
+          byPathGlobalLoaders = globalPage.data.functions;
           break;
         }
       }
       // Override this section key and props with found match
       const globalSection = overrideGlobalSection || byPathGlobalSection;
+      const globalLoaders = overrideGlobalLoaders || byPathGlobalLoaders;
       if (globalSection) {
         section.key = globalSection.key;
         section.label = globalSection.label;
         section.props = globalSection.props;
+        pageWithParams.page.data.functions = [
+          ...(globalLoaders ?? []),
+          ...(pageWithParams.page.data.functions ?? []),
+        ];
       }
     }
   }

--- a/pages.ts
+++ b/pages.ts
@@ -30,12 +30,7 @@ export async function loadLivePage(
 ): Promise<PageWithParams | null> {
   const url = new URL(req.url);
   const pageIdParam = url.searchParams.get("pageId");
-<<<<<<< HEAD
   const blockName = url.searchParams.get("key");
-=======
-  const sectionName = url.pathname.startsWith(sectionPathStart) &&
-    url.pathname.replace(sectionPathStart, "");
->>>>>>> 7b19de7 (Initial implementation of global section reference using page with global type)
   const pageId = pageIdParam && parseInt(pageIdParam, 10);
   let globals: Page[] = [];
 

--- a/types.ts
+++ b/types.ts
@@ -74,7 +74,7 @@ export interface PageData {
   functions: PageFunction[];
 }
 
-export type PageState = "archived" | "draft" | "published" | "dev";
+export type PageState = "archived" | "draft" | "published" | "dev" | "global";
 
 export interface Page {
   id: number;

--- a/utils/manifest.ts
+++ b/utils/manifest.ts
@@ -274,10 +274,11 @@ interface SectionInstance {
  */
 export const createSectionFromSectionKey = (
   sectionKey: string,
+  sectionName?: string,
 ): CreateSectionFromSectionKeyReturn => {
   const section: SectionInstance = {
     key: sectionKey,
-    label: sectionKey,
+    label: sectionKey + sectionName ? ` (${sectionName})` : "",
     uniqueId: sectionKey,
     props: {},
   };


### PR DESCRIPTION
Global sections are special pages (state=global) which contain 1 section and have a page path that starts with `/_live/workbench/sections/`

This PR allows pages to have a section with a key that points to a global section, which is then replaced with the contents of the section in the "global" page at `/_live/workbench/sections/:section`

Next PR: at the admin, to allow saving arbitrary sections from the library.