### PR TITLE
[Live@v1] Add schema builder

### DIFF
--- a/engine/core/mod.ts
+++ b/engine/core/mod.ts
@@ -14,7 +14,7 @@ export interface ResolverOptions<TContext extends BaseContext = BaseContext> {
 
 const withOverrides = (
   overrides: Record<string, string> | undefined,
-  resolvables: Record<string, Resolvable<any>>,
+  resolvables: Record<string, Resolvable<any>>
 ): Record<string, Resolvable<any>> => {
   return Object.entries(overrides ?? {}).reduce((nresolvables, [from, to]) => {
     return { ...nresolvables, [from]: nresolvables[to] };
@@ -36,10 +36,14 @@ export class ConfigResolver<TContext extends BaseContext = BaseContext> {
     };
   };
 
+  public setResolvables = (resolvables: Record<string, Resolvable<any>>) => {
+    this.resolvables = resolvables;
+  };
+
   public resolve = <T = any>(
     typeOrResolvable: string | Resolvable<T>,
     context: Omit<TContext, keyof BaseContext>,
-    overrides?: Record<string, string>,
+    overrides?: Record<string, string>
   ): PromiseOrValue<T> => {
     const { resolvers: res, resolvables } = this.config;
     const nresolvables = withOverrides(overrides, resolvables);
@@ -64,12 +68,13 @@ export class ConfigResolver<TContext extends BaseContext = BaseContext> {
         resolvers,
         data,
         nresolvables,
-        ctx as TContext,
+        ctx as TContext
       );
     }
-    const resolvable = typeof typeOrResolvable === "string"
-      ? nresolvables[typeOrResolvable]
-      : typeOrResolvable;
+    const resolvable =
+      typeof typeOrResolvable === "string"
+        ? nresolvables[typeOrResolvable]
+        : typeOrResolvable;
     if (resolvable === undefined) {
       return undefined as T;
     }
@@ -77,7 +82,7 @@ export class ConfigResolver<TContext extends BaseContext = BaseContext> {
       resolvers,
       resolvable,
       nresolvables,
-      ctx as TContext,
+      ctx as TContext
     );
   };
 }

--- a/engine/schema/builder.ts
+++ b/engine/schema/builder.ts
@@ -1,0 +1,354 @@
+import { JSONSchema7 } from "$live/deps.ts";
+import {
+  deepMergeDefinitions,
+  mergeJSONSchemas,
+} from "$live/engine/schema/merge.ts";
+import { fromFileUrl } from "std/path/mod.ts";
+import { schemeableToJSONSchema } from "$live/engine/schema/schemeable.ts";
+import { Schemeable } from "$live/engine/schema/transform.ts";
+
+export interface Schemas {
+  definitions: Record<string, JSONSchema7>;
+  root: Record<string, JSONSchema7>;
+}
+
+export interface BlockModule {
+  blockType: string;
+  functionKey: string; // this key should contain the module namespace
+  inputSchema?: Schemeable;
+  outputSchema?: Schemeable;
+}
+
+// FIXME it should have a better way to handle it @author Marcos V. Candeia
+export interface EntrypointModule {
+  key: string;
+  config: Schemeable;
+}
+
+interface ResolverRef {
+  blockType: string;
+  key: string;
+  inputSchemaIds: string[];
+  outputSchemaIds: string[];
+}
+
+const resolverRefToSchemeable = ({
+  key,
+  inputSchemaIds,
+}: ResolverRef): Schemeable => {
+  return {
+    name: "",
+    file: key,
+    friendlyId: key,
+    type: "inline",
+    value: {
+      title: key,
+      type: "object",
+      allOf: inputSchemaIds
+        ? [{ $ref: `#/definitions/${inputSchemaIds}` }]
+        : [],
+      required: ["__resolveType"],
+      properties: {
+        __resolveType: {
+          type: "string",
+          default: key,
+        },
+      },
+    },
+  };
+};
+export interface SchemaData {
+  schema: Schemas;
+  blockModules: BlockModule[];
+  entrypoints: EntrypointModule[];
+}
+export interface SchemaBuilder {
+  /**
+   * Returns the schema data raw
+   */
+  data: SchemaData;
+  /**
+   * Build the final schema.
+   * @param base the current directory.
+   * @param namespace the current repository namespace.
+   * @returns the built Schemas.
+   */
+  build(base: string, namespace: string): Schemas;
+  /**
+   * Merge with other schema (provided to a third-party manifest)
+   */
+  mergeWith(other: Schemas): SchemaBuilder;
+  /**
+   * Add a new block schema to the schema.
+   * @param blockSchema is the refernece to the configuration input and the blockfunction output
+   */
+  withBlockSchema(blockSchema: BlockModule | EntrypointModule): SchemaBuilder;
+}
+const mergeSchemasRoot = (
+  a: Schemas["root"],
+  b: Schemas["root"]
+): Schemas["root"] => {
+  const mergedRoot: Schemas["root"] = {};
+  const allRootBlocks = { ...a, ...b };
+
+  for (const block of Object.keys(allRootBlocks)) {
+    const duplicated: Record<string, boolean> = {};
+    mergedRoot[block] = {
+      title: block,
+      anyOf: [...(a[block]?.anyOf ?? []), ...(b[block]?.anyOf ?? [])].filter(
+        (ref) => {
+          const $ref = (ref as JSONSchema7).$ref!;
+          const has = duplicated[$ref!];
+          duplicated[$ref] = true;
+          return !has;
+        }
+      ),
+    };
+  }
+  return mergedRoot;
+};
+
+/**
+ * Best effort function. Trying to guess the organization/repository of a given file.
+ * fallsback to the complete file address.
+ * @param base is the current directory
+ * @param namespace is the current namespace
+ * @returns
+ */
+const canonicalFileWith =
+  (base: string, namespace: string) =>
+  (file: string): string => {
+    if (file.startsWith("https://denopkg.com")) {
+      const [url] = file.split("@");
+      return url.substring("https://denopkg.com".length + 1);
+    }
+    if (file.startsWith("file://")) {
+      const withoutFile = fromFileUrl(file);
+      if (withoutFile.startsWith(base)) {
+        return `${namespace}${withoutFile.replace(base, "")}`;
+      }
+      return withoutFile;
+    }
+    if (file.startsWith("./")) {
+      return `${namespace}${file.replace(".", "")}`;
+    }
+    if (file.startsWith("http")) {
+      const url = new URL(file);
+      // trying to guess, best effort
+      const [_, org, repo, _skipVersion, ...rest] = url.pathname.split("/");
+      return `${org}/${repo}/${rest.join("/")}`;
+    }
+    return file;
+  };
+const mergeStates = (a: JSONSchema7, b: JSONSchema7): JSONSchema7 => {
+  return {
+    ...a,
+    ...b,
+    required: [...(a?.required ?? []), ...(b?.required ?? [])],
+    properties: {
+      ...(a?.properties ?? {}),
+      ...(b?.properties ?? {}),
+    },
+  };
+};
+
+const isEntrypoint = (
+  m: BlockModule | EntrypointModule
+): m is EntrypointModule => {
+  return (m as EntrypointModule).key !== undefined;
+};
+export const newSchemaBuilder = (initial: SchemaData): SchemaBuilder => {
+  return {
+    data: initial,
+    mergeWith({ root, definitions }: Schemas): SchemaBuilder {
+      const newRoot = mergeSchemasRoot(initial.schema["root"], root);
+      const newRootState = mergeStates(
+        initial.schema["root"]["state"],
+        root.state
+      );
+      const newDefinitions = deepMergeDefinitions(
+        initial.schema["definitions"],
+        definitions
+      );
+      return newSchemaBuilder({
+        ...initial,
+        schema: {
+          root: { ...newRoot, state: newRootState },
+          definitions: newDefinitions,
+        },
+      });
+    },
+    withBlockSchema(schema: BlockModule | EntrypointModule): SchemaBuilder {
+      if (isEntrypoint(schema)) {
+        return newSchemaBuilder({
+          ...initial,
+          entrypoints: [...initial.entrypoints, schema],
+        });
+      }
+      // routes is always entrypoints
+      if (schema.blockType === "routes" && schema.inputSchema) {
+        return newSchemaBuilder({
+          ...initial,
+          entrypoints: [
+            ...initial.entrypoints,
+            {
+              key: schema.functionKey,
+              config: schema.inputSchema,
+            },
+          ],
+        });
+      }
+      return newSchemaBuilder({
+        ...initial,
+        blockModules: [...initial.blockModules, schema],
+      });
+    },
+    build(base: string, namespace: string) {
+      const canonical = canonicalFileWith(base, namespace);
+      const schemeableId = (
+        schemeable: Schemeable
+      ): [string, string | undefined] => {
+        const file = schemeable.file ? canonical(schemeable.file) : undefined;
+        if (schemeable.id) {
+          return [schemeable.id, file];
+        }
+        const fileHash = file ? btoa(file) : crypto.randomUUID();
+        const id = schemeable.name
+          ? `${fileHash}@${schemeable.name!}`
+          : fileHash;
+        return [id, file];
+      };
+      const genId = (s: Schemeable) => {
+        if (s.name !== undefined) {
+          return schemeableId(s)[0];
+        }
+        return undefined;
+      };
+      const addSchemeable = (
+        def: Schemas["definitions"],
+        schemeable?: Schemeable
+      ): [Schemas["definitions"], string[] | undefined] => {
+        if (schemeable) {
+          const [id, file] = schemeableId(schemeable);
+          let currSchemeable = {
+            friendlyId: `${file}@${schemeable.name}`,
+            ...schemeable,
+            id,
+          };
+          const ids = [id];
+          if (currSchemeable.type === "union") {
+            // if union generate id for each schemeable
+            const unionSchemeables = currSchemeable.value.map((s) => {
+              const [id, file] = schemeableId(s);
+              ids.push(id);
+              return {
+                friendlyId: `${file}@${s.name}`,
+                ...s,
+                id,
+              };
+            });
+            currSchemeable = { ...currSchemeable, value: unionSchemeables };
+          }
+          const [nDef] = schemeableToJSONSchema(genId, def, currSchemeable);
+          return [nDef, ids];
+        }
+        return [def, undefined];
+      };
+      // build all schemeable to JsonSchema
+      // generate schemeable id based on http and file system
+      const [d, r] = initial.blockModules.reduce(
+        ([def, resolvers], mod) => {
+          const [defOut, idOut] = addSchemeable(def, mod.outputSchema);
+          const [defIn, idIn] = addSchemeable(defOut, mod.inputSchema);
+          return [
+            defIn,
+            [
+              ...resolvers,
+              {
+                blockType: mod.blockType,
+                key: mod.functionKey,
+                inputSchemaIds: idIn ?? [], // supporting only one prop input for now @author Marcos V. Candeia
+                outputSchemaIds: idOut ? idOut : [],
+              },
+            ],
+          ];
+        },
+        [initial.schema.definitions, []] as [
+          Schemas["definitions"],
+          ResolverRef[]
+        ]
+      );
+      const [def, root] = r.reduce(
+        ([currentDefinitions, currentRoot], rs) => {
+          const schemeable = resolverRefToSchemeable(rs);
+          const [nDef, id] = addSchemeable(currentDefinitions, schemeable);
+          const funcSchema = id ? nDef[id[0]] : undefined;
+          const currAnyOfs = currentRoot[rs.blockType]?.anyOf ?? [];
+
+          const newDef = rs.outputSchemaIds.reduce(
+            (innerDefinitions, innerRoot) => {
+              const outSchema = currentDefinitions[innerRoot];
+              if (!outSchema) {
+                return innerDefinitions;
+              }
+              return {
+                ...innerDefinitions,
+                [innerRoot]: mergeJSONSchemas(
+                  outSchema as JSONSchema7,
+                  funcSchema!
+                ),
+              };
+            },
+            nDef
+          );
+          return [
+            newDef,
+            {
+              ...currentRoot,
+              [rs.blockType]: {
+                title: rs.blockType,
+                anyOf: [...currAnyOfs, { $ref: `#/definitions/${id}` }],
+              },
+            },
+          ];
+        },
+        [d, initial.schema.root] as [Schemas["definitions"], Schemas["root"]]
+      );
+      const configState = Object.keys(root).reduce(
+        (curr, key) => {
+          return { ...curr, anyOf: [...curr.anyOf, { $ref: `#/root/${key}` }] };
+        },
+        { anyOf: [] as JSONSchema7[] }
+      );
+      const [finalDefs, entrypoint] = initial.entrypoints.reduce(
+        ([defs, entr], blkEntry) => {
+          const [nDefs, id] = addSchemeable(defs, blkEntry.config);
+          return [
+            nDefs,
+            {
+              ...entr,
+              required: [...(entr.required ?? []), blkEntry.key],
+              properties: {
+                ...entr.properties,
+                [blkEntry.key]: {
+                  $ref: `#/definitions/${id}`,
+                },
+              },
+            },
+          ];
+        },
+        [
+          def,
+          {
+            type: "object",
+            required: [],
+            properties: {},
+            ...(root["state"] ?? {}), // should we include only catchall?
+            additionalProperties: configState,
+          },
+        ] as [Schemas["definitions"], JSONSchema7]
+      );
+      return { definitions: finalDefs, root: { ...root, state: entrypoint } };
+    },
+  };
+};

--- a/engine/schema/merge.ts
+++ b/engine/schema/merge.ts
@@ -1,0 +1,82 @@
+import { JSONSchema7 } from "$live/deps.ts";
+
+export const mergeJSONSchemas = (
+  defObj: JSONSchema7,
+  defOtherObj: JSONSchema7
+) => {
+  const bothNonUndefined = defObj && defOtherObj;
+  if (!bothNonUndefined) {
+    return defObj ?? defOtherObj;
+  }
+
+  const anyOf: JSONSchema7[] = [];
+  if (defObj.anyOf && defObj.anyOf.length > 0) {
+    anyOf.push(...(defObj.anyOf as JSONSchema7[]));
+  } else {
+    anyOf.push(defObj);
+  }
+
+  if (defOtherObj.anyOf && defOtherObj.anyOf.length > 0) {
+    anyOf.push(...(defOtherObj.anyOf as JSONSchema7[]));
+  } else {
+    anyOf.push(defOtherObj);
+  }
+
+  const alreadyAdded: Record<string, boolean> = {};
+
+  return {
+    anyOf: anyOf.filter((ref) => {
+      if (!ref.$id) {
+        return true;
+      }
+      const added = alreadyAdded[ref.$id];
+      alreadyAdded[ref.$id] = true;
+      return !added;
+    }),
+    $id: defObj.$id ?? defOtherObj.$id,
+  };
+};
+const isJSONSchema = <T>(s: T | JSONSchema7): s is JSONSchema7 => {
+  return (
+    (s as JSONSchema7)?.type !== undefined ||
+    (s as JSONSchema7)?.$ref !== undefined ||
+    (s as JSONSchema7)?.$id !== undefined ||
+    (s as JSONSchema7)?.anyOf !== undefined
+  );
+};
+export const deepMergeDefinitions = (
+  def: Record<string, JSONSchema7>,
+  defOther: Record<string, JSONSchema7>
+): Record<string, JSONSchema7> => {
+  const newObj: Record<string, JSONSchema7> = {};
+  for (const key of new Set([
+    ...Object.keys(def ?? {}),
+    ...Object.keys(defOther ?? {}),
+  ])) {
+    if (!def[key]) {
+      newObj[key] = defOther[key];
+    } else if (!defOther[key]) {
+      newObj[key] = def[key];
+    } else {
+      const defObj = def[key];
+      const defOtherObj = defOther[key];
+      if (isJSONSchema(defObj) && isJSONSchema(defOtherObj)) {
+        newObj[key] = mergeJSONSchemas(defObj, defOtherObj);
+      } else if (
+        typeof defObj === "object" &&
+        typeof defOtherObj === "object"
+      ) {
+        newObj[key] = deepMergeDefinitions(
+          defObj as Record<string, JSONSchema7>,
+          defOtherObj as Record<string, JSONSchema7>
+        );
+      } else {
+        console.warn(
+          `could not merge ${key} because its types diverges, defaulting to target.`
+        );
+        newObj[key] = defOtherObj;
+      }
+    }
+  }
+  return newObj;
+};


### PR DESCRIPTION
## Description

Add schema builder. It is used to build the final JSONSchema definitions used on manifest.


```ts
export interface SchemaBuilder {
  /**
   * Returns the schema data raw
   */
  data: SchemaData;
  /**
   * Build the final schema.
   * @param base the current directory.
   * @param namespace the current repository namespace.
   * @returns the built Schemas.
   */
  build(base: string, namespace: string): Schemas;
  /**
   * Merge with other schema (provided to a third-party manifest)
   */
  mergeWith(other: Schemas): SchemaBuilder;
  /**
   * Add a new block schema to the schema.
   * @param blockSchema is the refernece to the configuration input and the blockfunction output
   */
  withBlockSchema(blockSchema: BlockModule | EntrypointModule): SchemaBuilder;
}
```

The schema builder allows you to add new block schemas in the final generated JSONSchema, and build the schema Object by calling .build() 