### PR TITLE
feat: send metrics to iframe

### DIFF
--- a/components/LiveAnalytics.tsx
+++ b/components/LiveAnalytics.tsx
@@ -36,7 +36,7 @@ const main = (
     }
 
     if (isLocalhost) {
-      console.debug(
+      console.info(
         `[Performance]:`,
         name,
         typeof value === "number" ? value.toFixed(2) : value.length,

--- a/components/LiveAnalytics.tsx
+++ b/components/LiveAnalytics.tsx
@@ -1,95 +1,152 @@
 import { context } from "$live/live.ts";
-import { Head } from "$fresh/runtime.ts";
 import Script from "https://deno.land/x/partytown@0.2.1/Script.tsx";
 import Jitsu from "https://deno.land/x/partytown@0.2.1/integrations/Jitsu.tsx";
 import type { Flags, Page } from "$live/types.ts";
 
-const innerHtml = (
-  { id, path, flags = {} }: Partial<Page> & { flags?: Flags },
-) => `
-const onWebVitalsReport = (event) => {
-  window.jitsu('track', 'web-vitals', event);
-};
-
-/* Send exception error to jitsu */
-const onError = ( message, url, lineNo, columnNo, error) => {
-  if (typeof window.jitsu === 'function') {
-    window.jitsu('track', 'error', {error_1type: "Exception",message, url,  lineNo, columnNo, error_stack: error.stack, error_name: error.name})
+declare global {
+  interface Window {
+    jitsu: (...args: any[]) => void;
   }
 }
 
-const init = async () => {
-  if (typeof window.jitsu !== "function") {
-    return;
-  }
+const main = (
+  userData: {
+    page_id: string;
+    page_path: string;
+    site_id: string;
+    active_flags: string;
+  },
+) => {
+  const islands: string[] = [];
+  const loadingErrors: string[] = [];
 
-  /* Send scriptLoad event to jitsu */
-  __decoLoadingErrors.forEach((e) => window.jitsu('track', 'error',{error_type:"ScriptLoad", url: e.src}))
+  /**
+   * Send report to admin and console.debug
+   */
+  const reportPerformance = (
+    type: "web-vitals" | "islands",
+    name: string,
+    value: number | string[],
+    rating = "",
+  ) => {
+    const isLocalhost = location?.origin.includes("localhost");
 
-  /* Add these trackers to all analytics sent to our server */
-  window.jitsu('set', { page_id: "${id}", page_path: "${path}", site_id: "${context.siteId}", 
-    active_flags: "${Object.keys(flags).join(",")}"
-   });
-  /* Send page-view event */
-  window.jitsu('track', 'pageview');
+    if (top !== window) {
+      top?.postMessage({ type, args: { name, rating, value } }, "*");
+    }
 
-  /* Listen web-vitals */
-  const { onCLS, onFID, onLCP, onFCP, onTTFB } = await import("https://esm.sh/v99/web-vitals@3.1.0/es2022/web-vitals.js");
-      
-  onCLS(onWebVitalsReport);
-  onFID(onWebVitalsReport);
-  onLCP(onWebVitalsReport);
-  onFCP(onWebVitalsReport);
-  onTTFB(onWebVitalsReport);
-};
+    if (isLocalhost) {
+      console.debug(
+        `[Performance]:`,
+        name,
+        typeof value === "number" ? value.toFixed(2) : value.length,
+        rating,
+      );
+    }
+  };
+
+  const onWebVitalsReport = (event: unknown) => {
+    window.jitsu?.("track", "web-vitals", event);
+
+    reportPerformance("web-vitals", event.name, event.value, event.rating);
+  };
+
+  /* Send exception error to jitsu */
+  const onError = ({ message, url, lineNo, columnNo, error }: {
+    message: string;
+    url?: string;
+    lineNo?: number;
+    columnNo?: number;
+    error: Error;
+  }) =>
+    window.jitsu?.("track", "error", {
+      error_1type: "Exception",
+      message,
+      url,
+      lineNo,
+      columnNo,
+      error_stack: error.stack,
+      error_name: error.name,
+    });
+
+  requestIdleCallback(async () => {
+    reportPerformance("islands", "Islands", islands);
+
+    /* Listen web-vitals */
+    const webVitals = await import(
+      "https://esm.sh/v99/web-vitals@3.1.0/es2022/web-vitals.js"
+    );
+
+    webVitals.onCLS(onWebVitalsReport);
+    webVitals.onFID(onWebVitalsReport);
+    webVitals.onLCP(onWebVitalsReport);
+    webVitals.onFCP(onWebVitalsReport);
+    webVitals.onTTFB(onWebVitalsReport);
+
+    if (typeof window.jitsu !== "function") {
+      return;
+    }
+
+    /* Send scriptLoad event to jitsu */
+    loadingErrors.forEach((e) =>
+      window.jitsu("track", "error", { error_type: "ScriptLoad", url: e.src })
+    );
+
+    /* Add these trackers to all analytics sent to our server */
+    window.jitsu("set", { ...userData, page_islands: islands.join(",") });
+    /* Send page-view event */
+    window.jitsu("track", "pageview");
+  });
+
+  const isIsland = (src: string) =>
+    /(.*)\/_frsh\/js\/(.*)\/island-(.*)\.js$/g.test(src);
+
+  const scripts = document.querySelectorAll("script");
+
+  // Track script errors
+  scripts.forEach((script) => {
+    script.addEventListener("error", () => loadingErrors.push(script.src));
+
+    if (isIsland(script.src)) {
+      const [_, islandName] = script.src.split("island-");
+      islands.push(islandName.replace(".js", ""));
+    }
+  });
+
   /* Send exception error event to jitsu */
-  window.addEventListener('error', function ({message, url, lineNo, columnNo, error}) {
-    onError(message, url, lineNo, columnNo, error)})
-
-  if (document.readyState === 'complete') {
-      init();
-  } else {
-      window.addEventListener('load', init);
+  addEventListener("error", onError);
 };
+
+const innerHtml = (
+  { id, path, flags = {} }: Partial<Page> & { flags?: Flags },
+) =>
+  `(${main.toString()})({page_id: "${id}", page_path: "${path}", site_id: "${context.siteId}", active_flags: "${
+    Object.keys(flags).join(",")
+  }"});
 `;
 
 type Props = Partial<Page> & { flags?: Flags };
-
-// Get all the scripts and check which ones have errors
-const errorHandlingScript = `
-      window.__decoLoadingErrors = []
-      const scripts = document.querySelectorAll("script");
-      scripts.forEach((e) => {e.onerror = () => __decoLoadingErrors.push(e.src)})
-`;
 
 /**
  * We don't send Jitsu events on localhost by default, so
  * turn this flag on if you want to test the event sending code.
  */
-const IS_TESTING_JITSU = false;
+const IS_TESTING_JITSU = true;
 
 function LiveAnalytics({ id = -1, path = "defined_on_code", flags }: Props) {
   return (
     <>
-      <Head>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: errorHandlingScript,
-          }}
-        >
-        </script>
-      </Head>
+      <Script
+        type="module"
+        dangerouslySetInnerHTML={{ __html: innerHtml({ id, path, flags }) }}
+      />
+
       {(context.isDeploy || IS_TESTING_JITSU) && ( // Add analytcs in production only
         <Jitsu
           data-init-only="true"
           data-key="js.9wshjdbktbdeqmh282l0th.c354uin379su270joldy2"
         />
       )}
-
-      <Script
-        type="module"
-        dangerouslySetInnerHTML={{ __html: innerHtml({ id, path, flags }) }}
-      />
     </>
   );
 }

--- a/components/LiveAnalytics.tsx
+++ b/components/LiveAnalytics.tsx
@@ -20,11 +20,25 @@ const main = (
   const islands: string[] = [];
   const loadingErrors: string[] = [];
 
+  // More info at:
+  // https://stackoverflow.com/questions/9808307/how-to-get-the-number-of-dom-elements-used-in-a-web-page
+  const getTotalDOMSize = (element: Element | ShadowRoot = document.body) => {
+    let count = 0;
+    let child = element.firstElementChild;
+    while (child) {
+      count += getTotalDOMSize(child);
+      if (child.shadowRoot) count += getTotalDOMSize(child.shadowRoot);
+      child = child.nextElementSibling;
+      count++;
+    }
+    return count;
+  };
+
   /**
    * Send report to admin and console.debug
    */
   const reportPerformance = (
-    type: "web-vitals" | "islands",
+    type: "web-vitals" | "islands" | "dom-size",
     name: string,
     value: number | string[],
     rating = "",
@@ -38,9 +52,10 @@ const main = (
     if (isLocalhost) {
       console.info(
         `[Performance]:`,
-        `%c${name}`,
-        'font',
-        typeof value === "number" ? value.toFixed(2) : `${value.length}, islands: ${value.join(', ')}`,
+        name,
+        typeof value === "number"
+          ? value.toFixed(2)
+          : `${value.length}: ${value.join(", ")}`,
         rating,
       );
     }
@@ -71,6 +86,7 @@ const main = (
     });
 
   requestIdleCallback(async () => {
+    reportPerformance("dom-size", "dom-size", getTotalDOMSize());
     reportPerformance("islands", "Islands", islands);
 
     /* Listen web-vitals */

--- a/components/LiveAnalytics.tsx
+++ b/components/LiveAnalytics.tsx
@@ -38,8 +38,9 @@ const main = (
     if (isLocalhost) {
       console.info(
         `[Performance]:`,
-        name,
-        typeof value === "number" ? value.toFixed(2) : value.length,
+        `%c${name}`,
+        'font',
+        typeof value === "number" ? value.toFixed(2) : `${value.length}, islands: ${value.join(', ')}`,
         rating,
       );
     }
@@ -131,7 +132,7 @@ type Props = Partial<Page> & { flags?: Flags };
  * We don't send Jitsu events on localhost by default, so
  * turn this flag on if you want to test the event sending code.
  */
-const IS_TESTING_JITSU = true;
+const IS_TESTING_JITSU = false;
 
 function LiveAnalytics({ id = -1, path = "defined_on_code", flags }: Props) {
   return (

--- a/components/LiveControls.tsx
+++ b/components/LiveControls.tsx
@@ -4,7 +4,6 @@ import type { Flags, Page, Site } from "$live/types.ts";
 
 declare global {
   interface Window {
-    inspectVSCode: inspectVSCode.DomInspector;
     LIVE: {
       page: Page;
       site: Site;

--- a/utils/timings.ts
+++ b/utils/timings.ts
@@ -2,6 +2,8 @@ type Timing = { start: number; end?: number };
 
 type TimingKey = string;
 
+const slugify = (key: string) => key.replace(/\//g, ".");
+
 export function createServerTimings() {
   const timings: Record<string, Timing> = {};
 
@@ -17,7 +19,7 @@ export function createServerTimings() {
     return Object.entries(timings)
       .map(([key, timing]) => {
         const duration = (timing.end! - timing.start).toFixed(0);
-        return `${key};dur=${duration}`;
+        return `${slugify(key)};dur=${duration}`;
       })
       .join(", ");
   };


### PR DESCRIPTION
This PR is linked to https://github.com/deco-sites/admin/pull/239 and sends WebVitals metrics parent window when `window !== top`. Also, it adds some console info when developing on localhost: 

<img width="914" alt="image" src="https://user-images.githubusercontent.com/1753396/226381936-08099dcb-31d1-4dfe-accd-62498778220f.png">

To remove it from being shown, click on "levels" and remove "info" from chrome's dev tools
<img width="907" alt="image" src="https://user-images.githubusercontent.com/1753396/226382384-2b8b79ce-0a24-4098-be48-997914c6bb0c.png">
