### PR TITLE
feat: navigate to admin with page path encoded

### DIFF
--- a/components/LiveControls.tsx
+++ b/components/LiveControls.tsx
@@ -70,8 +70,19 @@ const main = () => {
       event.preventDefault();
       event.stopPropagation();
 
-      window.location.href =
-        `https://deco.cx/admin/${window.LIVE.site.id}/pages/${window.LIVE.page.id}`;
+      const href = new URL(
+        `/admin/${window.LIVE.site.id}/pages/${window.LIVE.page.id}`,
+        "https://deco.cx",
+      );
+
+      href.searchParams.set(
+        "pagePath",
+        encodeURIComponent(
+          `${window.location.pathname}${window.location.search}`,
+        ),
+      );
+
+      window.location.href = `${href}`;
     }
   };
 


### PR DESCRIPTION
Navigates to admin with current page path encoded in the url.

When clicking with a `.`, we would redirect the user to `/admin/${window.LIVE.site.id}/pages/${window.LIVE.page.id}`. After the changes proposed on this PR, we are now redirecting the user to:
```ts
/admin/${window.LIVE.site.id}/pages/${window.LIVE.page.id}?pagePath=${window.location.pathname}${window.location.search}
```