### PR TITLE
feat: set-cookies for loaders/actions

### DIFF
--- a/blocks/utils.ts
+++ b/blocks/utils.ts
@@ -40,7 +40,7 @@ async ($live: TConfig) => {
 };
 
 // deno-lint-ignore ban-types
-export type FnContext<TState = {}> = TState & {};
+export type FnContext<TState = {}> = TState & { response: Response };
 
 export type FnProps<
   TProps = any,
@@ -53,11 +53,11 @@ export const applyProps = <
 >(func: {
   default: FnProps<TProps, TResp>;
 }) =>
-async ($live: TProps, ctx: HttpContext<{ global: any }>) => { // by default use global state
+async ($live: TProps, ctx: HttpContext<{ global: any, response: Response }>) => { // by default use global state
   return await func.default(
     $live,
     ctx.request,
-    ctx?.context?.state?.global ?? {},
+    { ...ctx?.context?.state?.global, response: ctx.context.state.response },
   );
 };
 

--- a/blocks/utils.ts
+++ b/blocks/utils.ts
@@ -40,7 +40,9 @@ async ($live: TConfig) => {
 };
 
 // deno-lint-ignore ban-types
-export type FnContext<TState = {}> = TState & { response: Response };
+export type FnContext<TState = {}> = TState & {
+  response: { headers: Headers };
+};
 
 export type FnProps<
   TProps = any,
@@ -53,7 +55,10 @@ export const applyProps = <
 >(func: {
   default: FnProps<TProps, TResp>;
 }) =>
-async ($live: TProps, ctx: HttpContext<{ global: any, response: Response }>) => { // by default use global state
+async (
+  $live: TProps,
+  ctx: HttpContext<{ global: any; response: { headers: Headers } }>,
+) => { // by default use global state
   return await func.default(
     $live,
     ctx.request,

--- a/engine/block.ts
+++ b/engine/block.ts
@@ -17,6 +17,7 @@ export interface BlockModuleRef {
   inputSchema?: Schemeable;
   outputSchema?: Schemeable;
   functionRef: ImportString;
+  functionJSDoc?: JSONSchema7;
 }
 
 export type ResolverLike<T = any> = (...args: any[]) => PromiseOrValue<T>;

--- a/engine/introspect.ts
+++ b/engine/introspect.ts
@@ -15,6 +15,7 @@ import {
   TsTypeDef,
   TsTypeLiteralDef,
 } from "https://deno.land/x/deno_doc@0.58.0/lib/types.d.ts";
+import { jsDocToSchema } from "$live/engine/schema/utils.ts";
 
 type Key = string | number | symbol;
 
@@ -180,6 +181,7 @@ export const introspectAddr = async <
   }
 
   const baseBlockRef = {
+    functionJSDoc: func.jsDoc && jsDocToSchema(func.jsDoc),
     functionRef: path,
     outputSchema: includeReturn && fn.return
       ? await tsTypeToSchemeable(func, fn.return, root)

--- a/engine/schema/builder.ts
+++ b/engine/schema/builder.ts
@@ -14,6 +14,7 @@ export interface BlockModule {
   functionKey: string; // this key should contain the module namespace
   inputSchema?: Schemeable;
   outputSchema?: Schemeable;
+  functionJSDoc?: JSONSchema7;
 }
 
 // FIXME it should have a better way to handle it @author Marcos V. Candeia
@@ -27,6 +28,7 @@ interface ResolverRef {
   functionKey: string;
   inputSchemaId: string | undefined;
   outputSchemaId: string | undefined;
+  functionJSDoc?: JSONSchema7;
 }
 
 const resolvableRef = {
@@ -60,14 +62,16 @@ const resolvableReferenceSchema: JSONSchema7 = {
 const functionRefToSchemeable = ({
   functionKey,
   inputSchemaId,
+  functionJSDoc,
 }: ResolverRef): Schemeable => {
   return {
     name: "",
     file: functionKey,
-    friendlyId: functionKey,
+    friendlyId: functionJSDoc?.title || functionKey,
     type: "inline",
     value: {
       title: functionKey,
+      ...functionJSDoc,
       type: "object",
       allOf: inputSchemaId
         ? [{ $ref: `#/definitions/${inputSchemaId}` }]
@@ -231,6 +235,7 @@ export const newSchemaBuilder = (initial: SchemaData): SchemaBuilder => {
                 {
                   blockType: mod.blockType,
                   functionKey: mod.functionKey,
+                  functionJSDoc: mod.functionJSDoc,
                   inputSchemaId: idIn, // supporting only one prop input for now @author Marcos V. Candeia
                   outputSchemaId: idOut,
                 },

--- a/engine/schema/gen.ts
+++ b/engine/schema/gen.ts
@@ -84,6 +84,7 @@ export const genSchemasFromManifest = async (
             functionKey: ref.functionRef,
             inputSchema: ref.inputSchema,
             outputSchema: ref.outputSchema,
+            functionJSDoc: ref.functionJSDoc,
           };
         }
         return undefined;

--- a/engine/schema/utils.ts
+++ b/engine/schema/utils.ts
@@ -6,6 +6,7 @@ import {
   DocNodeFunction,
   JsDoc,
   JsDocTag,
+  JsDocTagUnsupported,
   JsDocTagValued,
   TsTypeDef,
   TsTypeFnOrConstructorDef,
@@ -44,7 +45,11 @@ export const jsDocToSchema = (node: JsDoc) =>
     ? Object.fromEntries(
       node.tags
         .map((tag: JsDocTag) => {
-          const match = (tag as JsDocTagValued).value.match(
+          if (tag.kind === "deprecated") {
+            return ["deprecated", true] as const;
+          }
+
+          const match = (tag as JsDocTagValued).value?.match(
             /^@(?<key>[a-zA-Z]+) (?<value>.*)$/,
           );
 

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -63,7 +63,7 @@ export const handler = async (
     return redirectToPreviewPage(url, url.searchParams.get("pageId")!);
   }
 
-  const response = new Response(null, { headers: new Headers(defaultHeaders) });
+  const response = { headers: new Headers(defaultHeaders) };
   const state = ctx.state?.$live?.state;
   if (state) {
     state.response = response;

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -63,8 +63,10 @@ export const handler = async (
     return redirectToPreviewPage(url, url.searchParams.get("pageId")!);
   }
 
+  const response = new Response(null, { headers: new Headers(defaultHeaders) });
   const state = ctx.state?.$live?.state;
   if (state) {
+    state.response = response;
     Object.assign(ctx.state, state);
     ctx.state.global = state; // compatibility mode with functions.
   }
@@ -73,6 +75,7 @@ export const handler = async (
   const initialResponse = await ctx.next();
 
   const newHeaders = new Headers(initialResponse.headers);
+  response.headers.forEach((value, key) => newHeaders.append(key, value));
   newHeaders.set("Server-Timing", ctx?.state?.t?.printTimings());
 
   if (
@@ -80,10 +83,6 @@ export const handler = async (
     [400, 404, 500].includes(initialResponse.status)
   ) {
     newHeaders.set("Cache-Control", "no-cache, no-store, private");
-  }
-
-  for (const [headerKey, headerValue] of Object.entries(defaultHeaders)) {
-    newHeaders.set(headerKey, headerValue);
   }
 
   const newResponse = new Response(initialResponse.body, {


### PR DESCRIPTION
This PR adds a new response to context. This response is copied when generating the final response. So, setting set-cookie headers on this response will lead to setting the response cookie of the server