### PR TITLE
Proxy handler

### DIFF
--- a/engine/configstore/fs.ts
+++ b/engine/configstore/fs.ts
@@ -1,0 +1,47 @@
+import { join } from "std/path/mod.ts";
+import { exists } from "../../utils/filesystem.ts";
+import { singleFlight } from "../core/utils.ts";
+import { ConfigStore } from "./provider.ts";
+
+const sample = {
+  "audience-everyone": {
+    overrides: {},
+    routes: {
+      "/google": {
+        to: "https://www.google.com",
+        __resolveType: "$live/handlers/redirect.ts",
+      },
+    },
+    __resolveType: "$live/flags/everyone.ts",
+  },
+  "./routes/[...catchall].tsx": {
+    handler: {
+      audiences: [
+        {
+          __resolveType: "audience-everyone",
+        },
+      ],
+      __resolveType: "$live/handlers/routesSelection.ts",
+    },
+    __resolveType: "resolve",
+  },
+};
+export const newFsProvider = (
+  path = ".configs.json",
+): ConfigStore => {
+  // deno-lint-ignore no-explicit-any
+  const sf = singleFlight<Record<string, any>>();
+  const fullPath = join(Deno.cwd(), path);
+
+  const load = async () => {
+    if (!(await exists(fullPath))) {
+      await Deno.writeTextFile(fullPath, JSON.stringify(sample, null, 2));
+      return sample;
+    }
+    return JSON.parse(await Deno.readTextFile(fullPath));
+  };
+  return {
+    state: () => sf.do("load", load),
+    archived: () => sf.do("load", load),
+  };
+};

--- a/engine/configstore/fs.ts
+++ b/engine/configstore/fs.ts
@@ -7,9 +7,9 @@ const sample = {
   "audience-everyone": {
     overrides: {},
     routes: {
-      "/google": {
-        to: "https://www.google.com",
-        __resolveType: "$live/handlers/redirect.ts",
+      "/*": {
+        url: "https://www.google.com",
+        __resolveType: "$live/handlers/proxy.ts",
       },
     },
     __resolveType: "$live/flags/everyone.ts",

--- a/engine/configstore/provider.ts
+++ b/engine/configstore/provider.ts
@@ -3,6 +3,7 @@ import { fromPagesTable } from "$live/engine/configstore/pages.ts";
 import { Resolvable } from "$live/engine/core/resolver.ts";
 import { context } from "$live/live.ts";
 import { newSupabase } from "./supabaseProvider.ts";
+import { newFsProvider } from "./fs.ts";
 
 export interface ReadOptions {
   forceFresh?: boolean;
@@ -45,6 +46,9 @@ export const getComposedConfigStore = (
   site: string,
   siteId: number,
 ): ConfigStore => {
+  if (Deno.env.has("USE_LOCAL_STORAGE")) {
+    return newFsProvider();
+  }
   if (siteId <= 0) { // new sites does not have siteId
     return newSupabase(fromConfigsTable(site));
   }

--- a/engine/configstore/provider.ts
+++ b/engine/configstore/provider.ts
@@ -47,14 +47,18 @@ export const getComposedConfigStore = (
   siteId: number,
 ): ConfigStore => {
   const providers = [];
-  if (Deno.env.has("USE_LOCAL_STORAGE")) {
-    providers.push(newFsProvider());
-  }
+
   if (siteId > 0) {
     providers.push(newSupabase(fromPagesTable(siteId, ns), context.isDeploy)); // if not deploy so no background is needed
   }
+
+  providers.push(newSupabase(fromConfigsTable(site), context.isDeploy)); // if not deploy so no background is needed
+
+  if (Deno.env.has("USE_LOCAL_STORAGE")) {
+    providers.push(newFsProvider());
+  }
+
   return compose(
     ...providers,
-    newSupabase(fromConfigsTable(site), context.isDeploy), // if not deploy so no background is needed
   );
 };

--- a/handlers/proxy.ts
+++ b/handlers/proxy.ts
@@ -11,41 +11,48 @@ const HOP_BY_HOP = [
   "Proxy-Authenticate",
 ];
 
-const proxyTo = (proxyUrl: string): Handler => async (req, _ctx) => {
-  const url = new URL(req.url);
-  const qs = url.searchParams.toString();
-  const to = new URL(`${proxyUrl}/${url.pathname}?${qs}`);
+const proxyTo =
+  (proxyUrl: string, basePath?: string): Handler => async (req, _ctx) => {
+    const url = new URL(req.url);
+    const qs = url.searchParams.toString();
+    const path = basePath && basePath.length > 0
+      ? url.pathname.replace(basePath, "")
+      : url.pathname;
 
-  const headers = new Headers(req.headers);
-  HOP_BY_HOP.forEach((h) => headers.delete(h));
-  headers.set("origin", to.origin);
-  headers.set("host", to.host);
-  headers.set("x-forwarded-host", url.host);
+    const to = new URL(
+      `${proxyUrl}/${path}?${qs}`,
+    );
 
-  const response = await fetch(to, {
-    headers,
-    redirect: "manual",
-    method: req.method,
-    body: req.body,
-  });
+    const headers = new Headers(req.headers);
+    HOP_BY_HOP.forEach((h) => headers.delete(h));
+    headers.set("origin", to.origin);
+    headers.set("host", to.host);
+    headers.set("x-forwarded-host", url.host);
 
-  // Change cookies domain
-  const responseHeaders = new Headers(response.headers);
-  const cookies = getSetCookies(responseHeaders);
-  responseHeaders.delete("set-cookie");
+    const response = await fetch(to, {
+      headers,
+      redirect: "manual",
+      method: req.method,
+      body: req.body,
+    });
 
-  // Setting cookies on GET requests prevent cache from cdns, slowing down the app
-  if (req.method !== "GET") {
-    for (const cookie of cookies) {
-      setCookie(responseHeaders, { ...cookie, domain: url.hostname });
+    // Change cookies domain
+    const responseHeaders = new Headers(response.headers);
+    const cookies = getSetCookies(responseHeaders);
+    responseHeaders.delete("set-cookie");
+
+    // Setting cookies on GET requests prevent cache from cdns, slowing down the app
+    if (req.method !== "GET") {
+      for (const cookie of cookies) {
+        setCookie(responseHeaders, { ...cookie, domain: url.hostname });
+      }
     }
-  }
 
-  return new Response(response.body, {
-    status: response.status,
-    headers: responseHeaders,
-  });
-};
+    return new Response(response.body, {
+      status: response.status,
+      headers: responseHeaders,
+    });
+  };
 
 export interface Props {
   /**
@@ -53,8 +60,13 @@ export interface Props {
    * @example https://bravtexfashionstore.vtexcommercestable.com.br/api
    */
   url: string;
+  /**
+   * @description the base path of the url.
+   * @example /api
+   */
+  basePath?: string;
 }
 
-export default function Proxy({ url }: Props) {
-  return proxyTo(url);
+export default function Proxy({ url, basePath }: Props) {
+  return proxyTo(url, basePath);
 }

--- a/handlers/proxy.ts
+++ b/handlers/proxy.ts
@@ -55,6 +55,6 @@ export interface Props {
   url: string;
 }
 
-export function Proxy({ url }: Props) {
+export default function Proxy({ url }: Props) {
   return proxyTo(url);
 }

--- a/handlers/proxy.ts
+++ b/handlers/proxy.ts
@@ -1,0 +1,60 @@
+import { getSetCookies, Handler, setCookie } from "std/http/mod.ts";
+
+const HOP_BY_HOP = [
+  "Keep-Alive",
+  "Transfer-Encoding",
+  "TE",
+  "Connection",
+  "Trailer",
+  "Upgrade",
+  "Proxy-Authorization",
+  "Proxy-Authenticate",
+];
+
+const proxyTo = (proxyUrl: string): Handler => async (req, _ctx) => {
+  const url = new URL(req.url);
+  const qs = url.searchParams.toString();
+  const to = new URL(`${proxyUrl}/${url.pathname}?${qs}`);
+
+  const headers = new Headers(req.headers);
+  HOP_BY_HOP.forEach((h) => headers.delete(h));
+  headers.set("origin", to.origin);
+  headers.set("host", to.host);
+  headers.set("x-forwarded-host", url.host);
+
+  const response = await fetch(to, {
+    headers,
+    redirect: "manual",
+    method: req.method,
+    body: req.body,
+  });
+
+  // Change cookies domain
+  const responseHeaders = new Headers(response.headers);
+  const cookies = getSetCookies(responseHeaders);
+  responseHeaders.delete("set-cookie");
+
+  // Setting cookies on GET requests prevent cache from cdns, slowing down the app
+  if (req.method !== "GET") {
+    for (const cookie of cookies) {
+      setCookie(responseHeaders, { ...cookie, domain: url.hostname });
+    }
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    headers: responseHeaders,
+  });
+};
+
+export interface Props {
+  /**
+   * @description the proxy url.
+   * @example https://bravtexfashionstore.vtexcommercestable.com.br/api
+   */
+  url: string;
+}
+
+export function Proxy({ url }: Props) {
+  return proxyTo(url);
+}

--- a/live.gen.ts
+++ b/live.gen.ts
@@ -22,12 +22,13 @@ import * as $$$$$$$$0 from "./sections/UseSlot.tsx";
 import * as $$$$$$$$1 from "./sections/Slot.tsx";
 import * as $$$$$$$$2 from "./sections/PageInclude.tsx";
 import * as $$$$$$$$$0 from "./matchers/MatchDate.ts";
-import * as $$$$$$$$$1 from "./matchers/MatchUserAgent.ts";
-import * as $$$$$$$$$2 from "./matchers/MatchSite.ts";
-import * as $$$$$$$$$3 from "./matchers/MatchMulti.ts";
-import * as $$$$$$$$$4 from "./matchers/MatchRandom.ts";
-import * as $$$$$$$$$5 from "./matchers/MatchEnvironment.ts";
-import * as $$$$$$$$$6 from "./matchers/MatchAlways.ts";
+import * as $$$$$$$$$1 from "./matchers/MatchOrigin.ts";
+import * as $$$$$$$$$2 from "./matchers/MatchUserAgent.ts";
+import * as $$$$$$$$$3 from "./matchers/MatchSite.ts";
+import * as $$$$$$$$$4 from "./matchers/MatchMulti.ts";
+import * as $$$$$$$$$5 from "./matchers/MatchRandom.ts";
+import * as $$$$$$$$$6 from "./matchers/MatchEnvironment.ts";
+import * as $$$$$$$$$7 from "./matchers/MatchAlways.ts";
 import * as $$$$$$$$$$0 from "./flags/audience.ts";
 import * as $$$$$$$$$$1 from "./flags/everyone.ts";
 import * as $live_catchall from "$live/routes/[...catchall].tsx";
@@ -60,13 +61,14 @@ const manifest = {
     "$live/sections/UseSlot.tsx": $$$$$$$$0,
   },
   "matchers": {
-    "$live/matchers/MatchAlways.ts": $$$$$$$$$6,
+    "$live/matchers/MatchAlways.ts": $$$$$$$$$7,
     "$live/matchers/MatchDate.ts": $$$$$$$$$0,
-    "$live/matchers/MatchEnvironment.ts": $$$$$$$$$5,
-    "$live/matchers/MatchMulti.ts": $$$$$$$$$3,
-    "$live/matchers/MatchRandom.ts": $$$$$$$$$4,
-    "$live/matchers/MatchSite.ts": $$$$$$$$$2,
-    "$live/matchers/MatchUserAgent.ts": $$$$$$$$$1,
+    "$live/matchers/MatchEnvironment.ts": $$$$$$$$$6,
+    "$live/matchers/MatchMulti.ts": $$$$$$$$$4,
+    "$live/matchers/MatchOrigin.ts": $$$$$$$$$1,
+    "$live/matchers/MatchRandom.ts": $$$$$$$$$5,
+    "$live/matchers/MatchSite.ts": $$$$$$$$$3,
+    "$live/matchers/MatchUserAgent.ts": $$$$$$$$$2,
   },
   "flags": {
     "$live/flags/audience.ts": $$$$$$$$$$0,

--- a/live.gen.ts
+++ b/live.gen.ts
@@ -15,7 +15,8 @@ import * as $$$$7 from "./routes/[...catchall].tsx";
 import * as $$$$$$0 from "./handlers/routesSelection.ts";
 import * as $$$$$$1 from "./handlers/router.ts";
 import * as $$$$$$2 from "./handlers/devPage.ts";
-import * as $$$$$$3 from "./handlers/fresh.ts";
+import * as $$$$$$3 from "./handlers/proxy.ts";
+import * as $$$$$$4 from "./handlers/fresh.ts";
 import * as $$$$$$$0 from "./pages/LivePage.tsx";
 import * as $$$$$$$$0 from "./sections/UseSlot.tsx";
 import * as $$$$$$$$1 from "./sections/Slot.tsx";
@@ -45,7 +46,8 @@ const manifest = {
   },
   "handlers": {
     "$live/handlers/devPage.ts": $$$$$$2,
-    "$live/handlers/fresh.ts": $$$$$$3,
+    "$live/handlers/fresh.ts": $$$$$$4,
+    "$live/handlers/proxy.ts": $$$$$$3,
     "$live/handlers/router.ts": $$$$$$1,
     "$live/handlers/routesSelection.ts": $$$$$$0,
   },

--- a/matchers/MatchOrigin.ts
+++ b/matchers/MatchOrigin.ts
@@ -1,0 +1,19 @@
+import { MatchContext } from "$live/blocks/matcher.ts";
+
+export interface Props {
+  includes?: string;
+  match?: string;
+}
+
+const MatchOrigin = (
+  { includes, match }: Props,
+  { request }: MatchContext,
+) => {
+  const origin = request.headers.get("origin") || "";
+  const regexMatch = match ? new RegExp(match).test(origin) : true;
+  const includesFound = includes ? origin.includes(includes) : true;
+
+  return regexMatch && includesFound;
+};
+
+export default MatchOrigin;

--- a/schemas.gen.json
+++ b/schemas.gen.json
@@ -14,6 +14,7 @@
             "enum": [
               "$live/handlers/devPage.ts",
               "$live/handlers/fresh.ts",
+              "$live/handlers/proxy.ts",
               "$live/handlers/router.ts",
               "$live/handlers/routesSelection.ts",
               "$live/pages/LivePage.tsx",
@@ -63,6 +64,28 @@
         "page"
       ],
       "title": "$live/handlers/fresh.ts@FreshConfig"
+    },
+    "JGxpdmUvaGFuZGxlcnMvcHJveHkudHM=@Props": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "the proxy url.",
+          "title": "Url"
+        },
+        "basePath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "the base path of the url.",
+          "title": "Base Path"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "title": "$live/handlers/proxy.ts@Props"
     },
     "JGxpdmUvYmxvY2tzL2hhbmRsZXIudHM=@Handler": {
       "$ref": "#/root/handlers",
@@ -493,6 +516,27 @@
         }
       }
     },
+    "JGxpdmUvaGFuZGxlcnMvcHJveHkudHM=": {
+      "title": "$live/handlers/proxy.ts",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/JGxpdmUvaGFuZGxlcnMvcHJveHkudHM=@Props"
+        }
+      ],
+      "required": [
+        "__resolveType"
+      ],
+      "properties": {
+        "__resolveType": {
+          "type": "string",
+          "enum": [
+            "$live/handlers/proxy.ts"
+          ],
+          "default": "$live/handlers/proxy.ts"
+        }
+      }
+    },
     "JGxpdmUvaGFuZGxlcnMvcm91dGVyLnRz": {
       "title": "$live/handlers/router.ts",
       "type": "object",
@@ -849,6 +893,9 @@
         },
         {
           "$ref": "#/definitions/JGxpdmUvaGFuZGxlcnMvZnJlc2gudHM="
+        },
+        {
+          "$ref": "#/definitions/JGxpdmUvaGFuZGxlcnMvcHJveHkudHM="
         },
         {
           "$ref": "#/definitions/JGxpdmUvaGFuZGxlcnMvcm91dGVyLnRz"

--- a/schemas.gen.json
+++ b/schemas.gen.json
@@ -25,6 +25,7 @@
               "$live/matchers/MatchDate.ts",
               "$live/matchers/MatchEnvironment.ts",
               "$live/matchers/MatchMulti.ts",
+              "$live/matchers/MatchOrigin.ts",
               "$live/matchers/MatchRandom.ts",
               "$live/matchers/MatchSite.ts",
               "$live/matchers/MatchUserAgent.ts",
@@ -378,6 +379,27 @@
         "matchers"
       ],
       "title": "$live/matchers/MatchMulti.ts@Props"
+    },
+    "JGxpdmUvbWF0Y2hlcnMvTWF0Y2hPcmlnaW4udHM=@Props": {
+      "type": "object",
+      "properties": {
+        "includes": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "title": "Includes"
+        },
+        "match": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "title": "Match"
+        }
+      },
+      "required": [],
+      "title": "$live/matchers/MatchOrigin.ts@Props"
     },
     "JGxpdmUvbWF0Y2hlcnMvTWF0Y2hSYW5kb20udHM=@Props": {
       "type": "object",
@@ -742,6 +764,27 @@
         }
       }
     },
+    "JGxpdmUvbWF0Y2hlcnMvTWF0Y2hPcmlnaW4udHM=": {
+      "title": "$live/matchers/MatchOrigin.ts",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/JGxpdmUvbWF0Y2hlcnMvTWF0Y2hPcmlnaW4udHM=@Props"
+        }
+      ],
+      "required": [
+        "__resolveType"
+      ],
+      "properties": {
+        "__resolveType": {
+          "type": "string",
+          "enum": [
+            "$live/matchers/MatchOrigin.ts"
+          ],
+          "default": "$live/matchers/MatchOrigin.ts"
+        }
+      }
+    },
     "JGxpdmUvbWF0Y2hlcnMvTWF0Y2hSYW5kb20udHM=": {
       "title": "$live/matchers/MatchRandom.ts",
       "type": "object",
@@ -950,6 +993,9 @@
         },
         {
           "$ref": "#/definitions/JGxpdmUvbWF0Y2hlcnMvTWF0Y2hNdWx0aS50cw=="
+        },
+        {
+          "$ref": "#/definitions/JGxpdmUvbWF0Y2hlcnMvTWF0Y2hPcmlnaW4udHM="
         },
         {
           "$ref": "#/definitions/JGxpdmUvbWF0Y2hlcnMvTWF0Y2hSYW5kb20udHM="


### PR DESCRIPTION
# Description
This Pr adds two new blocks:

1. Proxy handler
Proxy requests to a specified url
2. MatchOrigin
A matcher that test regex or include against the header `origin`

Also, it adds support for local testing.

# How to test

1. clone the [fashion](https://github.com/deco-sites/fashion) store
2. run `USE_LOCAL_STORAGE=true deno task start`

Navigate to your `localhost:8000` again and you should be able to see the google homepage.
<img width="1720" alt="image" src="https://user-images.githubusercontent.com/5839364/236559453-e13c5a10-6e5c-4af7-9ad4-e6e12281b812.png">
