### PR TITLE
feat: Inline Editor handle outside block and slot sections

### DIFF
--- a/components/LivePageEditor.tsx
+++ b/components/LivePageEditor.tsx
@@ -253,7 +253,7 @@ export default function LivePageEditor() {
           id="_live_css"
           dangerouslySetInnerHTML={{
             __html: `
-            section[data-manifest-key]:before {
+            section[data-manifest-key]:not(:has(section[data-manifest-key])):before {
               content: '';
               display: none;
               position: absolute;
@@ -264,13 +264,13 @@ export default function LivePageEditor() {
               border-color: #2E6ED9;
             }
 
-        section[data-manifest-key]:hover {
+        section[data-manifest-key]:not(:has(section[data-manifest-key])):hover {
           position: relative;
         }
 
-        section[data-manifest-key]:hover:before,
-        section[data-manifest-key]:hover div[data-controllers],
-        section[data-manifest-key]:hover div[data-insert] {
+        section[data-manifest-key]:not(:has(section[data-manifest-key])):hover:before,
+        section[data-manifest-key]:not(:has(section[data-manifest-key])):hover div[data-controllers],
+        section[data-manifest-key]:not(:has(section[data-manifest-key])):hover div[data-insert] {
           display: flex;
         }
 

--- a/components/LivePageEditor.tsx
+++ b/components/LivePageEditor.tsx
@@ -128,8 +128,7 @@ function PreviewIcons() {
 interface DefaultEditorEvent {
   action: "move" | "edit" | "duplicate" | "delete" | "insert";
   key: string;
-  // TODO: Bump this version
-  /* @deprecated since version @1.0.x */
+  /* @deprecated since version @1.3.5 */
   index: number;
   path: string[];
 }

--- a/engine/core/resolver.ts
+++ b/engine/core/resolver.ts
@@ -69,9 +69,7 @@ type ResolveTypeOf<
   T = any,
   TContext extends BaseContext = BaseContext,
   TResolverMap extends ResolverMap<TContext> = ResolverMap<TContext>,
-> =
-  | keyof ResolvesTo<T, TContext, TResolverMap>
-  | ((arg: any) => keyof ResolvesTo<T, TContext, TResolverMap>);
+> = keyof ResolvesTo<T, TContext, TResolverMap>;
 
 export type ResolvableOf<
   T,
@@ -125,19 +123,13 @@ const resolveTypeOf = <
   resolvable: Resolvable<T, TContext, TResolverMap, TResolvableMap>,
 ): [
   Omit<T, "__resolveType">,
-  ((args: any) => keyof ResolverMap | string) | undefined,
+  string | undefined,
 ] => {
   if (isResolvable(resolvable)) {
     const { __resolveType, ...rest } = resolvable;
-    if (typeof __resolveType === "function") {
-      return [
-        rest as Omit<T, "__resolveType">,
-        __resolveType as (args: any) => keyof ResolverMap,
-      ];
-    }
     return [
       rest as Omit<T, "__resolveType">,
-      (() => __resolveType!) as (args: any) => keyof ResolverMap,
+      __resolveType,
     ];
   }
   return [resolvable as Omit<T, "__resolveType">, undefined];
@@ -287,6 +279,7 @@ export const withResolveChain = <T extends BaseContext = BaseContext>(
     },
   };
 };
+
 export const resolve = async <
   T,
   TContext extends BaseContext = BaseContext,
@@ -295,33 +288,40 @@ export const resolve = async <
   context: TContext,
 ): Promise<T> => {
   const { resolvers: resolverMap, resolvables } = context;
-  const [resolvableObj, type] = resolveTypeOf(resolvable);
-  const tpResolver = nativeResolverByType[typeof resolvableObj];
-  if (type === undefined) {
+
+  // get the __resolveType from the resolvable
+  const [resolvableObj, resolveType] = resolveTypeOf(resolvable);
+
+  // define the type resolver based on the object type
+  const typeResolver = nativeResolverByType[typeof resolvableObj];
+
+  // if the resolveType is not defined we should use the typeresolver
+  if (resolveType === undefined) {
+    // since array is also an object so we should check it strictly instead
     if (Array.isArray(resolvableObj)) {
-      return await tpResolver<T, TContext>(
+      return await typeResolver<T, TContext>(
         resolvableObj,
         (data) => resolve(data, context),
       );
     }
     return resolvableObj as T;
   }
-  const resolved = await tpResolver<T, TContext>(
+
+  const ctx = withResolveChain(context, resolveType);
+  const resolved = await typeResolver<T, TContext>(
     resolvableObj,
     (data) =>
       resolve(
         data,
-        typeof type === "string" ? withResolveChain(context, type) : context,
+        ctx,
       ),
   );
-  const resolverType = type(resolved);
-  const ctx = withResolveChain(context, resolverType);
-  const resolver = resolverMap[resolverType];
+  const resolver = resolverMap[resolveType];
   if (resolver !== undefined) {
     let end: (() => void) | undefined = undefined;
     let respOrPromise = resolver(resolved, ctx);
     if (isAwaitable(respOrPromise)) {
-      const timingName = resolverType.replaceAll("/", ".");
+      const timingName = resolveType.replaceAll("/", ".");
       end = ctx.monitoring?.t.start(timingName);
       respOrPromise = await respOrPromise;
 
@@ -340,10 +340,10 @@ export const resolve = async <
     }
     return resolve(respOrPromise, ctx);
   }
-  const resolvableRef = resolvables[resolverType.toString()] as Resolvable<T>;
+  const resolvableRef = resolvables[resolveType] as Resolvable<T>;
   if (resolvableRef === undefined) {
     if (!ctx.danglingRecover) {
-      throw new DanglingReference(resolverType.toString());
+      throw new DanglingReference(resolveType);
     }
     return ctx.danglingRecover(resolved, ctx);
   }

--- a/pages/LivePage.tsx
+++ b/pages/LivePage.tsx
@@ -36,7 +36,7 @@ export function renderSectionFor(editMode?: boolean) {
         data-manifest-key={metadata?.component}
       >
         <Controls metadata={metadata} index={idx} />
-        <Section preview={editMode} {...props} />
+        <Section editMode={editMode} {...props} />
       </section>
     );
   };

--- a/pages/LivePage.tsx
+++ b/pages/LivePage.tsx
@@ -24,7 +24,7 @@ export interface Props {
   sections: Section[];
 }
 
-function renderSectionFor(editMode?: boolean) {
+export function renderSectionFor(editMode?: boolean) {
   const Controls = editMode ? BlockControls : () => null;
   return function _renderSection(
     { Component: Section, props, metadata }: Props["sections"][0],
@@ -36,7 +36,7 @@ function renderSectionFor(editMode?: boolean) {
         data-manifest-key={metadata?.component}
       >
         <Controls metadata={metadata} index={idx} />
-        <Section {...props} />
+        <Section preview={editMode} {...props} />
       </section>
     );
   };

--- a/pages/LivePage.tsx
+++ b/pages/LivePage.tsx
@@ -37,6 +37,7 @@ export function renderSectionFor(editMode?: boolean) {
     { Component: Section, props, metadata }: Props["sections"][0],
     idx: number,
   ) {
+    // TODO: Remove editMode at Section Props and pass via context
     return (
       <section
         id={`${metadata?.component}-${idx}`}
@@ -75,7 +76,6 @@ function indexedBySlotName(
   sections.forEach((section, index) => {
     if (isSection(section, USE_SLOT_SECTION_KEY)) {
       // This is used to maintain the real position during editMode
-      // TODO: check maybe can use metadata
       (section.props as any).__previewIndex = index;
       indexed[section.props.name] = {
         useSection: section,
@@ -83,7 +83,6 @@ function indexedBySlotName(
       };
     } else {
       // This is used to maintain the real position during editMode
-      // TODO: check maybe can use metadata
       section.props.__previewIndex = index;
       contentSections.push(section);
     } // others are considered content

--- a/pages/LivePage.tsx
+++ b/pages/LivePage.tsx
@@ -74,12 +74,17 @@ function indexedBySlotName(
 
   sections.forEach((section, index) => {
     if (isSection(section, USE_SLOT_SECTION_KEY)) {
+      // This is used to maintain the real position during editMode
+      // TODO: check maybe can use metadata
       (section.props as any).__previewIndex = index;
       indexed[section.props.name] = {
         useSection: section,
         used: false,
       };
     } else {
+      // This is used to maintain the real position during editMode
+      // TODO: check maybe can use metadata
+      section.props.__previewIndex = index;
       contentSections.push(section);
     } // others are considered content
   });
@@ -155,6 +160,7 @@ const renderPage = (
     const unmatchedSections = unmatchedSlots.flatMap((impl) =>
       Array.isArray(impl.useSection) ? impl.useSection : [impl.useSection]
     );
+
     return (
       <>
         {rendered}

--- a/sections/PageInclude.tsx
+++ b/sections/PageInclude.tsx
@@ -3,11 +3,12 @@ import { notUndefined } from "$live/engine/core/utils.ts";
 
 import {
   Props as LivePageProps,
-  renderSection,
+  renderSectionFor,
 } from "$live/pages/LivePage.tsx";
 
 export interface Props {
   page: Page;
+  editMode?: boolean;
 }
 
 export const isLivePageProps = (
@@ -17,10 +18,13 @@ export const isLivePageProps = (
     (p as LivePageProps)?.layout !== undefined;
 };
 
-export default function PageInclude({ page }: Props) {
+export default function PageInclude({ page, editMode }: Props) {
   if (!isLivePageProps(page?.props)) {
     return null;
   }
+
+  const renderSection = renderSectionFor(editMode);
+
   return (
     <>{(page?.props?.sections ?? []).filter(notUndefined).map(renderSection)}</>
   );

--- a/sections/PageInclude.tsx
+++ b/sections/PageInclude.tsx
@@ -8,7 +8,6 @@ import {
 
 export interface Props {
   page: Page;
-  editMode?: boolean;
 }
 
 export const isLivePageProps = (
@@ -18,12 +17,12 @@ export const isLivePageProps = (
     (p as LivePageProps)?.layout !== undefined;
 };
 
-export default function PageInclude({ page, editMode }: Props) {
+export default function PageInclude({ page, ...rest }: Props) {
   if (!isLivePageProps(page?.props)) {
     return null;
   }
 
-  const renderSection = renderSectionFor(editMode);
+  const renderSection = renderSectionFor((rest as any).editMode);
 
   return (
     <>{(page?.props?.sections ?? []).filter(notUndefined).map(renderSection)}</>

--- a/sections/PageInclude.tsx
+++ b/sections/PageInclude.tsx
@@ -22,6 +22,7 @@ export default function PageInclude({ page, ...rest }: Props) {
     return null;
   }
 
+  // TODO: get render section from page context.
   const renderSection = renderSectionFor((rest as any).editMode);
 
   return (

--- a/sections/UseSlot.tsx
+++ b/sections/UseSlot.tsx
@@ -1,19 +1,21 @@
 import { Section } from "$live/blocks/section.ts";
 import { notUndefined } from "$live/engine/core/utils.ts";
-import { renderSection } from "$live/pages/LivePage.tsx";
+import { renderSectionFor } from "$live/pages/LivePage.tsx";
 import { WellKnownSlots } from "$live/sections/Slot.tsx";
 
 export interface Props {
   name: string | WellKnownSlots;
   sections: Section[];
+  editMode?: boolean;
 }
 
-export default function UseSlot({ sections }: Props) {
+export default function UseSlot({ sections, editMode }: Props) {
+  // TODO: Check performance impact here
+  const renderSection = renderSectionFor(editMode);
+
   return (
-    (
-      <>
-        {(sections ?? []).filter(notUndefined).map(renderSection)}
-      </>
-    )
+    <>
+      {(sections ?? []).filter(notUndefined).map(renderSection)}
+    </>
   );
 }

--- a/sections/UseSlot.tsx
+++ b/sections/UseSlot.tsx
@@ -6,12 +6,11 @@ import { WellKnownSlots } from "$live/sections/Slot.tsx";
 export interface Props {
   name: string | WellKnownSlots;
   sections: Section[];
-  editMode?: boolean;
 }
 
-export default function UseSlot({ sections, editMode }: Props) {
+export default function UseSlot({ sections, ...rest }: Props) {
   // TODO: Check performance impact here
-  const renderSection = renderSectionFor(editMode);
+  const renderSection = renderSectionFor((rest as any).editMode);
 
   return (
     <>

--- a/sections/UseSlot.tsx
+++ b/sections/UseSlot.tsx
@@ -9,7 +9,7 @@ export interface Props {
 }
 
 export default function UseSlot({ sections, ...rest }: Props) {
-  // TODO: Check performance impact here
+  // TODO: get render section from page context.
   const renderSection = renderSectionFor((rest as any).editMode);
 
   return (


### PR DESCRIPTION
This PR improves the Inline Editor:
- Handles outside block
- Use Slot sections
- Fixes resolve chain (https://github.com/deco-cx/live.ts/pull/226/commits/2bf9385fd6439962ded9a39540531e0d62a525d7)