### PR TITLE
fix: Unexpected end of JSON input on Invoke

### DIFF
--- a/routes/live/invoke/[...key].ts
+++ b/routes/live/invoke/[...key].ts
@@ -25,5 +25,9 @@ export const handler = async (
 
   const resp = await resolve(payloadForFunc(invokeFunc));
 
+  if (resp === undefined) {
+    return new Response(null, { status: 204 });
+  }
+
   return Response.json(resp);
 };

--- a/routes/live/invoke/[...key].ts
+++ b/routes/live/invoke/[...key].ts
@@ -24,10 +24,6 @@ export const handler = async (
   };
 
   const resp = await resolve(payloadForFunc(invokeFunc));
-  if (resp instanceof Object) {
-    return Response.json(
-      resp,
-    );
-  }
-  return new Response(null, { status: 200 });
+
+  return Response.json(resp);
 };

--- a/routes/live/invoke/index.ts
+++ b/routes/live/invoke/index.ts
@@ -43,7 +43,7 @@ export type ManifestLoader<
   ? TManifest["loaders"][TLoader] extends { default: infer TLoader }
     ? TLoader extends (
       props: infer Props,
-    req: Request,
+      req: Request,
       _ctx: any,
     ) => PromiseOrValue<infer TReturn> ? { props: Props; return: TReturn }
     : never
@@ -57,7 +57,7 @@ export type ManifestAction<
   ? TManifest["actions"][TAction] extends { default: infer TAction }
     ? TAction extends (
       props: infer Props,
-    req: Request,
+      req: Request,
       _ctx: any,
     ) => PromiseOrValue<infer TReturn> ? { props: Props; return: TReturn }
     : never
@@ -246,10 +246,6 @@ export const handler = async (
     : bodyFromUrl("body", new URL(req.url));
 
   const resp = await resolve(payloadToResolvable(data));
-  if (resp instanceof Object) {
-    return Response.json(
-      resp,
-    );
-  }
-  return new Response(null, { status: 200 });
+
+  return Response.json(resp);
 };

--- a/routes/live/invoke/index.ts
+++ b/routes/live/invoke/index.ts
@@ -247,5 +247,9 @@ export const handler = async (
 
   const resp = await resolve(payloadToResolvable(data));
 
+  if (resp === undefined) {
+    return new Response(null, { status: 204 });
+  }
+
   return Response.json(resp);
 };


### PR DESCRIPTION
As title says, we were receiving a null response from invoke. This caused the `fetch().then(response => response.json())` break with the error `Uncaught (in promise) SyntaxError: Unexpected end of JSON input`

After this change, we return a `null` as json, so the aforementioned issue is fixed