### PR TITLE
chore: Pass renderSection via context

### DIFF
--- a/engine/block.ts
+++ b/engine/block.ts
@@ -187,6 +187,12 @@ export type ComponentFunc<
 export interface ComponentMetadata {
   resolveChain: string[];
   component: string;
+  /**
+   * This property is used to reference child position, during LivePage edit mode.
+   *
+   * Ex.: Sections inside UseSlot has indexes different from the Slot itself. In this case, UseSlot adds this `real` childIndex.
+   */
+  childIndex?: number;
 }
 
 export interface PageContext {

--- a/pages/LivePage.tsx
+++ b/pages/LivePage.tsx
@@ -18,7 +18,8 @@ import {
 import { isLivePageProps } from "$live/sections/PageInclude.tsx";
 import { CONTENT_SLOT_NAME } from "$live/sections/Slot.tsx";
 import { Props as UseSlotProps } from "$live/sections/UseSlot.tsx";
-import { ComponentChildren, JSX } from "preact";
+import { ComponentChildren, createContext, JSX } from "preact";
+import { useContext } from "preact/hooks";
 
 export interface Props {
   name: string;
@@ -46,7 +47,7 @@ export function renderSectionFor(editMode?: boolean) {
       >
         <EditContext metadata={metadata} index={props.__previewIndex ?? idx}>
           <Controls />
-          <Section editMode={editMode} {...props} />
+          <Section {...props} />
         </EditContext>
       </section>
     );
@@ -176,6 +177,14 @@ const renderPage = (
   );
 };
 
+interface LivePageContext {
+  renderSection: ReturnType<typeof renderSectionFor>;
+}
+const LivePageContext = createContext<LivePageContext>({
+  renderSection: renderSectionFor(),
+});
+export const useLivePageContext = () => useContext(LivePageContext);
+
 export default function LivePage(
   props: Props,
 ): JSX.Element {
@@ -207,12 +216,14 @@ export function Preview(props: Props) {
   const editMode = pageCtx?.url.searchParams.has("editMode") ?? false;
 
   return (
-    <>
+    <LivePageContext.Provider
+      value={{ renderSection: renderSectionFor(editMode) }}
+    >
       <Head>
         <meta name="robots" content="noindex, nofollow" />
       </Head>
       {renderPage(props, {}, editMode)}
       {editMode && <LivePageEditor />}
-    </>
+    </LivePageContext.Provider>
   );
 }

--- a/pages/LivePage.tsx
+++ b/pages/LivePage.tsx
@@ -45,7 +45,7 @@ export function renderSectionFor(editMode?: boolean) {
         id={`${metadata?.component}-${idx}`}
         data-manifest-key={metadata?.component}
       >
-        <EditContext metadata={metadata} index={props.__previewIndex ?? idx}>
+        <EditContext metadata={metadata} index={metadata?.childIndex ?? idx}>
           <Controls />
           <Section {...props} />
         </EditContext>
@@ -78,14 +78,18 @@ function indexedBySlotName(
   sections.forEach((section, index) => {
     if (isSection(section, USE_SLOT_SECTION_KEY)) {
       // This is used to maintain the real position during editMode
-      (section.props as any).__previewIndex = index;
+      if (section.metadata) {
+        section.metadata.childIndex = index;
+      }
       indexed[section.props.name] = {
         useSection: section,
         used: false,
       };
     } else {
       // This is used to maintain the real position during editMode
-      section.props.__previewIndex = index;
+      if (section.metadata) {
+        section.metadata.childIndex = index;
+      }
       contentSections.push(section);
     } // others are considered content
   });

--- a/sections/PageInclude.tsx
+++ b/sections/PageInclude.tsx
@@ -3,7 +3,7 @@ import { notUndefined } from "$live/engine/core/utils.ts";
 
 import {
   Props as LivePageProps,
-  renderSectionFor,
+  useLivePageContext,
 } from "$live/pages/LivePage.tsx";
 
 export interface Props {
@@ -17,13 +17,12 @@ export const isLivePageProps = (
     (p as LivePageProps)?.layout !== undefined;
 };
 
-export default function PageInclude({ page, ...rest }: Props) {
+export default function PageInclude({ page }: Props) {
   if (!isLivePageProps(page?.props)) {
     return null;
   }
 
-  // TODO: get render section from page context.
-  const renderSection = renderSectionFor((rest as any).editMode);
+  const { renderSection } = useLivePageContext();
 
   return (
     <>{(page?.props?.sections ?? []).filter(notUndefined).map(renderSection)}</>

--- a/sections/UseSlot.tsx
+++ b/sections/UseSlot.tsx
@@ -1,6 +1,6 @@
 import { Section } from "$live/blocks/section.ts";
 import { notUndefined } from "$live/engine/core/utils.ts";
-import { renderSectionFor } from "$live/pages/LivePage.tsx";
+import { useLivePageContext } from "$live/pages/LivePage.tsx";
 import { WellKnownSlots } from "$live/sections/Slot.tsx";
 
 export interface Props {
@@ -8,9 +8,8 @@ export interface Props {
   sections: Section[];
 }
 
-export default function UseSlot({ sections, ...rest }: Props) {
-  // TODO: get render section from page context.
-  const renderSection = renderSectionFor((rest as any).editMode);
+export default function UseSlot({ sections }: Props) {
+  const { renderSection } = useLivePageContext();
 
   return (
     <>


### PR DESCRIPTION
Avoid coupling untyped props between UseSlot and PageInclude with LivePage