### PR TITLE
Allow only valid cookie names on audience name

### DIFF
--- a/flags/audience.ts
+++ b/flags/audience.ts
@@ -13,6 +13,12 @@ export interface Override {
 }
 export interface Audience {
   matcher: Matcher;
+  /**
+   * @title Add a meaningful short word for the audience name.
+   * @maxLength 22
+   * @minLength 3
+   * @pattern ^[A-Za-z0-9_]+$
+   */
   name: string;
   routes?: Route[];
   overrides?: Override[];

--- a/flags/audience.ts
+++ b/flags/audience.ts
@@ -14,7 +14,8 @@ export interface Override {
 export interface Audience {
   matcher: Matcher;
   /**
-   * @title Add a meaningful short word for the audience name.
+   * @title The audience name (will be used on cookies).
+   * @description Add a meaningful short word for the audience name.
    * @maxLength 22
    * @minLength 3
    * @pattern ^[A-Za-z0-9_]+$

--- a/handlers/proxy.ts
+++ b/handlers/proxy.ts
@@ -48,6 +48,20 @@ const proxyTo =
         setCookie(responseHeaders, { ...cookie, domain: url.hostname });
       }
     }
+    if (response.status >= 300 && response.status < 400) { // redirect change location header
+      const location = responseHeaders.get("location");
+      if (location) {
+        responseHeaders.set(
+          "location",
+          location.replace(
+            proxyUrl,
+            `${url.protocol}://${url.host}${
+              url.port === "443" || url.port === "80" ? "" : `:${url.port}`
+            }`,
+          ),
+        );
+      }
+    }
 
     return new Response(response.body, {
       status: response.status,

--- a/schemas.gen.json
+++ b/schemas.gen.json
@@ -728,7 +728,8 @@
         },
         "name": {
           "type": "string",
-          "title": "Add a meaningful short word for the audience name.",
+          "title": "The audience name (will be used on cookies).",
+          "description": "Add a meaningful short word for the audience name.",
           "maxLength": 22,
           "minLength": 3,
           "pattern": "^[A-Za-z0-9_]+$"

--- a/schemas.gen.json
+++ b/schemas.gen.json
@@ -728,7 +728,10 @@
         },
         "name": {
           "type": "string",
-          "title": "Name"
+          "title": "Add a meaningful short word for the audience name.",
+          "maxLength": 22,
+          "minLength": 3,
+          "pattern": "^[A-Za-z0-9_]+$"
         },
         "routes": {
           "$ref": "#/definitions/JGxpdmUvZmxhZ3MvYXVkaWVuY2UudHM=@Route[]",


### PR DESCRIPTION
Previously names with whitespace are allowed but isn't a valid cookie so browser complains about.